### PR TITLE
Added complete support for MSI MAG274QRF-QD and the new firmware revision

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ information by opening an issue.
 | MAG272QR      | ?        | Partial 1)    | "V18" | "00G"| ?              |
 | MAG272R       | ?        | ?             | "V18" | "00O"| ?              |
 | MAG274QRF-QD  | FW.011   | WIP           | "V43" | "00e"| AUO_M270DAN08_2|
+| MAG274QRF-QD  | FW.015   | WIP           | "V48" | "00e"| AUO_M270DAN08_2|
 | MAG321CQR     | ?        | Yes           | "V18" | "00:"| ?              |
 | MAG321CURV    | FW.009   | Yes           | "V18" | "00;"| SAM_LSM315FP01 |
 | MAG322CQR     | ?        | ?             | ?     |   ?  | ?              |
@@ -703,32 +704,57 @@ MPG341 Series:
       --navi_left            RW values: off brightness game_mode screen_assistance alarm_clock input refresh_rate audio_volume 
       --navi_right           RW values: off brightness game_mode screen_assistance alarm_clock input refresh_rate audio_volume 
 
-MAG274 Series:
-    These options apply to the MAG274 Series:
+MAG274QRF-QD FW.011:
+    These options apply to the MAG274QRF-QD FW.011:
 
-      --mode                 RW values: user fps racing rts rpg mode5 mode6 mode7 mode8 mode9 user reader cinema designer HDR 
-      --game_mode            RW values: user fps racing rts rpg 
-      --enable_dynamic       RW values: on off 
-      --hdcr                 RW values: off on 
-      --refresh_display      RW values: off on 
-      --refresh_position     RW values: left_top right_top left_bottom right_bottom 
-      --alarm_clock          RW values: off 1 2 3 4 
-      --free_sync            RW values: off on 
-      --zero_latency         RW values: off on 
-      --screen_size          RW values: auto 4:3 16:9 
-      --night_vision         RW values: off normal strong strongest ai 
-      --pro_mode             RW values: user reader cinema designer HDR 
-      --eye_saver            RW values: off on 
-      --color_preset         RW values: cool normal warm custom 
+      --mode                 RW values: user fps racing rts rpg mode5 mode6 mode7 mode8 mode9 user reader cinema office
+      --game_mode            RW values: user fps racing rts rpg
+      --enable_dynamic       RW values: on off
+      --hdcr                 RW values: off on
+      --refresh_display      RW values: off on
+      --refresh_position     RW values: left_top right_top left_bottom right_bottom
+      --alarm_clock          RW values: off 1 2 3 4
+      --free_sync            RW values: off on
+      --night_vision         RW values: off normal strong strongest ai
+      --pro_mode             RW values: user reader cinema office
+      --eye_saver            RW values: off on
+      --color_preset         RW values: cool normal warm custom
       --color_red            RW values: 0 to 100
       --color_green          RW values: 0 to 100
       --color_blue           RW values: 0 to 100
-      --input                RW values: hdmi1 hdmi2 dp usbc 
-      --rgb_led              RW values: off on 
-      --navi_up              RW values: off brightness game_mode screen_assistance alarm_clock refresh_rate info 
-      --navi_down            RW values: off brightness game_mode screen_assistance alarm_clock refresh_rate info 
-      --navi_left            RW values: off brightness game_mode screen_assistance alarm_clock refresh_rate info 
-      --navi_right           RW values: off brightness game_mode screen_assistance alarm_clock refresh_rate info 
+      --input                RW values: hdmi1 hdmi2 dp usbc
+      --screen_info          RW values: off on
+      --rgb_led              RW values: off on
+      --navi_up              RW values: off brightness game_mode screen_assistance alarm_clock input refresh_rate info
+      --navi_down            RW values: off brightness game_mode screen_assistance alarm_clock input refresh_rate info
+      --navi_left            RW values: off brightness game_mode screen_assistance alarm_clock input refresh_rate info
+      --navi_right           RW values: off brightness game_mode screen_assistance alarm_clock input refresh_rate info
+
+MAG274QRF-QD FW.015:
+    These options apply to the MAG274QRF-QD FW.015:
+
+      --mode                 RW values: user fps racing rts rpg mode5 mode6 mode7 mode8 mode9 user reader cinema office srgb adobe_rgb dci_p3
+      --game_mode            RW values: user fps racing rts rpg
+      --enable_dynamic       RW values: on off
+      --hdcr                 RW values: off on
+      --refresh_display      RW values: off on
+      --refresh_position     RW values: left_top right_top left_bottom right_bottom
+      --alarm_clock          RW values: off 1 2 3 4
+      --free_sync            RW values: off on
+      --night_vision         RW values: off normal strong strongest ai
+      --pro_mode             RW values: user reader cinema office srgb adobe_rgb dci_p3
+      --eye_saver            RW values: off on
+      --color_preset         RW values: cool normal warm custom
+      --color_red            RW values: 0 to 100
+      --color_green          RW values: 0 to 100
+      --color_blue           RW values: 0 to 100
+      --input                RW values: hdmi1 hdmi2 dp usbc
+      --screen_info          RW values: off on
+      --rgb_led              RW values: off on
+      --navi_up              RW values: off brightness game_mode screen_assistance alarm_clock input refresh_rate info
+      --navi_down            RW values: off brightness game_mode screen_assistance alarm_clock input refresh_rate info
+      --navi_left            RW values: off brightness game_mode screen_assistance alarm_clock input refresh_rate info
+      --navi_right           RW values: off brightness game_mode screen_assistance alarm_clock input refresh_rate info
 
 PS Series:
     These options apply to the PS Series:
@@ -939,6 +965,6 @@ virtual guests booting up.
 [Marco Rodolfi](https://github.com/RodoMa92) - MAG274QRF-QD support
 
 [Preston](https://github.com/PChild) - Multi-Monitor support
-[
+
 [Michael J Brancato](https://github.com/sgtcoder) - Multi-Monitor support
 

--- a/src/msigd.cpp
+++ b/src/msigd.cpp
@@ -107,7 +107,7 @@ static std::vector<identity_t> known_models =
 	{ MAG271CQ,          "001", "V18", "MPG27 Series", LT_STEEL },   // MPG27CQ
 	{ MPG341,            "00>", "V09", "MPG341 Series", LT_STEEL },    // MPG27CQR
 	{ MAG274QRFQD,       "00e", "V43", "MAG274QRF-QD FW.011", LT_MYSTIC },  // MAG274QRF-QD FW.011
-	{ MAG274QRFQDNEW,    "00e", "V48", "MAG274QRF-QD FW.015", LT_MYSTIC },  // MAG274QRF-QD FW.015
+	{ MAG274QRFQDNEW,    "00e", "V48", "MAG274QRF-QD FW.015/FW.016", LT_MYSTIC },  // MAG274QRF-QD FW.015/FW.016
 	{ PS,                "00?", "V06", "PS Series", LT_NONE }
 };
 

--- a/src/msigd.cpp
+++ b/src/msigd.cpp
@@ -42,17 +42,20 @@ enum access_t
 
 enum series_t
 {
-	UNKNOWN   = 0x0000,
-	MAG32     = 0x0001,
-	MAG321    = 0x0002,
-	MAG241    = 0x0004,
-	MAG271CQ  = 0x0008,
-	MAG272    = 0x0010,
-	PS        = 0x0020,
-	MPG341    = 0x0040,
-	QUERYONLY = 0x1000,
+	UNKNOWN        = 0x0000,
+	MAG32          = 0x0001,
+	MAG321         = 0x0002,
+	MAG241         = 0x0004,
+	MAG271CQ       = 0x0008,
+	MAG272         = 0x0010,
+	MAG274QRFQD    = 0x0020,
+	MAG274QRFQDNEW = 0x0040,
+	PS             = 0x0080,
+	MPG341         = 0x0100,
+	QUERYONLY      = 0x1000,
 
-	MAG     = MAG32 | MAG321 | MAG272 | MAG271CQ | MAG241,
+	MAG     = MAG32 | MAG321 | MAG272 | MAG271CQ | MAG241 | MAG274QRFQD | MAG274QRFQDNEW,
+	MAG274 	= MAG274QRFQD | MAG274QRFQDNEW,
 	ALL     = MAG | PS | MPG341 | QUERYONLY,
 };
 
@@ -88,23 +91,24 @@ struct identity_t
 
 static std::vector<identity_t> known_models =
 {
-	{ UNKNOWN,   "",     "", "Unknown", LT_NONE },
-	{ QUERYONLY, "",     "", "Unknown Series", LT_NONE },
-	{ MAG32,     "00;", "V18", "MAG32 Series", LT_MYSTIC },
-	{ MAG321,    "00:", "V18", "MAG321CQR", LT_MYSTIC }, // doesn't have USBC
-	{ MAG241,    "002", "V18", "MAG241 Series", LT_NONE },
+	{ UNKNOWN,           "",     "", "Unknown", LT_NONE },
+	{ QUERYONLY,         "",     "", "Unknown Series", LT_NONE },
+	{ MAG32,             "00;", "V18", "MAG32 Series", LT_MYSTIC },
+	{ MAG321,            "00:", "V18", "MAG321CQR", LT_MYSTIC }, // doesn't have USBC
+	{ MAG241,            "002", "V18", "MAG241 Series", LT_NONE },
 	// FIXME: Needs separate series (has RGB backlight OSD setting) - above not
-	{ MAG241,    "004", "V18", "MAG241CR Series", LT_MYSTIC }, // MAG241CR
-	{ MAG241,    "005", "V18", "MAG271CR Series", LT_MYSTIC }, // MAG271CR
-	{ MAG271CQ,  "006", "V19", "MAG271CQ Series", LT_MYSTIC }, // MAG271CQR, MAG271CQP
-	{ MAG272,    "00O", "V18", "MAG272QP Series", LT_MYSTIC }, // MAG272QP
-	{ MAG272,    "00L", "V18", "MAG272 Series", LT_MYSTIC }, // MAG272
-	{ MAG272,    "00E", "V18", "MAG272CQR Series", LT_MYSTIC }, // MAG272CQR
-	{ MAG272,    "00G", "V18", "MAG272QR Series", LT_MYSTIC }, // MAG272QR
-	{ MAG271CQ,  "001", "V18", "MPG27 Series", LT_STEEL },   // MPG27CQ
-	{ MPG341,    "00>", "V09", "MPG341 Series", LT_STEEL },    // MPG27CQR
-	{ MAG272,    "00e", "V43", "MAG274 Series", LT_MYSTIC },  // MAG274QRF-QD
-	{ PS,        "00?", "V06", "PS Series", LT_NONE }
+	{ MAG241,            "004", "V18", "MAG241CR Series", LT_MYSTIC }, // MAG241CR
+	{ MAG241,            "005", "V18", "MAG271CR Series", LT_MYSTIC }, // MAG271CR
+	{ MAG271CQ,          "006", "V19", "MAG271CQ Series", LT_MYSTIC }, // MAG271CQR, MAG271CQP
+	{ MAG272,            "00O", "V18", "MAG272QP Series", LT_MYSTIC }, // MAG272QP
+	{ MAG272,            "00L", "V18", "MAG272 Series", LT_MYSTIC }, // MAG272
+	{ MAG272,            "00E", "V18", "MAG272CQR Series", LT_MYSTIC }, // MAG272CQR
+	{ MAG272,            "00G", "V18", "MAG272QR Series", LT_MYSTIC }, // MAG272QR
+	{ MAG271CQ,          "001", "V18", "MPG27 Series", LT_STEEL },   // MPG27CQ
+	{ MPG341,            "00>", "V09", "MPG341 Series", LT_STEEL },    // MPG27CQR
+	{ MAG274QRFQD,       "00e", "V43", "MAG274QRF-QD FW.011", LT_MYSTIC },  // MAG274QRF-QD FW.011
+	{ MAG274QRFQDNEW,    "00e", "V48", "MAG274QRF-QD FW.015", LT_MYSTIC },  // MAG274QRF-QD FW.015
+	{ PS,                "00?", "V06", "PS Series", LT_NONE }
 };
 
 enum encoding_t
@@ -480,6 +484,9 @@ static std::vector<setting_t *> settings(
 	new setting_t(ALL, WRITE,              "00100", "power", {"off", "-on"}),
 	new setting_t(ALL, READ,               "00110", "macro_key", {"off", "pressed"}),  // returns 000 called frequently by OSD app, readonly
 	new setting_t(MAG272,                  "00120", "mode", {"user", "fps", "racing", "rts", "rpg", "mode5", "mode6", "mode7", "mode8", "mode9", "user", "reader", "cinema", "designer", "HDR"}),
+	new setting_t(MAG274QRFQD,             "00120", "mode", {"user", "fps", "racing", "rts", "rpg", "mode5", "mode6", "mode7", "mode8", "mode9", "user", "reader", "cinema", "office"}), //Supported modes in FW.011
+	new setting_t(MAG274QRFQDNEW,          "00120", "mode", {"user", "fps", "racing", "rts", "rpg", "mode5", "mode6", "mode7", "mode8", "mode9", "user", "reader", "cinema",
+	    "office", "srgb", "adobe_rgb", "dci_p3"}), //New moded added to FW.015
 	new setting_t(MAG32 | MAG321,          "00120", "mode", {"user", "fps", "racing", "rts", "rpg", "mode5", "mode6", "mode7", "mode8", "mode9", "user", "reader", "cinema", "designer"}),
 	new setting_t(PS,                      "00120", "mode", {"-m0","-m1","-m2","-m3","-m4""-m5","-m6","-m7","-m8","-m9",
 		"user", "adobe_rgb", "dci_p3", "srgb", "hdr", "cinema", "reader", "bw", "dicom", "eyecare", "cal1", "cal2", "cal3"}),
@@ -521,6 +528,9 @@ static std::vector<setting_t *> settings(
 	new alarm4x_t(MAG32,                   "001f",  "alarm4x"),
 
 	// MPG341: screen_assistance returns invalid results
+	// MAG274QRF-QD FW.015: Setting the cursor works only for half the whites (the first tree, white1 to white3, not 4 to 6);
+	// The reds are working correctly. The software complains that the write to the setting fails. Reading them back after
+	// setting them from the monitor UI returns correctly white4 to white6, so I'm not sure where the issue lies.
 	new setting_t(MAG,                     "00270", "screen_assistance", 100, {"off", "red1", "red2", "red3", "red4", "red5", "red6",
 		"white1", "white2", "white3", "white4", "white5", "white6"}),
 	new setting_t(PS,                      "00270", "screen_assistance", {"off", "center", "edge",
@@ -531,7 +541,7 @@ static std::vector<setting_t *> settings(
 	// Disabled for security reasons
 	new setting_t(UNKNOWN /*MAG32*/,       "00280", "unknown280"),  // returns 000, read only, write fails and monitor needs off/on cycle
 
-	new setting_t(MAG321 | MAG272 | MAG271CQ | MAG241 | MPG341,
+	new setting_t(MAG321 | MAG272 | MAG271CQ | MAG241 | MPG341 | MAG274,
 		                                   "00280", "free_sync", {"off", "on"}),
 	new setting_t(MAG32 | MAG321 | MAG272 | MAG271CQ | MPG341,
 		                                   "00290", "zero_latency", {"off", "on"}),  // returns 001
@@ -542,8 +552,10 @@ static std::vector<setting_t *> settings(
 	new setting_t(MAG32 | MAG321 | MAG271CQ,
 		                                   "002:0", "screen_size", {"19", "24", "4:3", "16:9"}),
 	new setting_t(PS | MPG341,             "002:0", "screen_size", {"auto", "4:3", "16:9", "21:9", "1:1"}),
-	new setting_t(MAG32 | MAG272 | MPG341, "002;0", "night_vision", {"off", "normal", "strong", "strongest", "ai"}),
+	new setting_t(MAG32 | MAG272 | MPG341 | MAG274, "002;0", "night_vision", {"off", "normal", "strong", "strongest", "ai"}),
 	new setting_t(MAG272,                  "00300", "pro_mode", {"user", "reader", "cinema", "designer", "HDR"}),
+	new setting_t(MAG274QRFQD,             "00300", "pro_mode", {"user", "reader", "cinema", "office"}),
+	new setting_t(MAG274QRFQDNEW,          "00300", "pro_mode", {"user", "reader", "cinema", "office", "srgb", "adobe_rgb", "dci_p3"}),
 	new setting_t(MAG32 | MAG321 | MAG271CQ | MAG241 | MPG341,
 		                                   "00300", "pro_mode", {"user", "reader", "cinema", "designer"}),
 	new setting_t(PS,                      "00300", "pro_mode", {"user", "adobe_rgb", "dci_p3", "srgb", "hdr", "cinema", "reader", "bw", "dicom", "eyecare", "cal1", "cal2", "cal3"}),
@@ -578,7 +590,7 @@ static std::vector<setting_t *> settings(
 	new tripple_t(PS,                      "004;0", "saturation_rgb"),
 	new tripple_t(PS,                      "004;1", "saturation_cmy"),
 	new setting_t(PS,                      "004:0", "gamma", {"1.8", "2", "2.2", "2.4", "2.6"}),
-	new setting_t(MAG32 | MAG272 | PS | MPG341,
+	new setting_t(MAG32 | MAG272 | PS | MPG341 | MAG274,
 		                                   "00500", "input",  {"hdmi1", "hdmi2", "dp", "usbc"}),  // returns 002  -> 0=hdmi1, 1=hdmi2, 2=dp, 3=usbc
 	new setting_t(MAG321| MAG271CQ | MAG241, "00500", "input",  {"hdmi1", "hdmi2", "dp"}),
 	new setting_t(MAG32 | MAG321 | MAG271CQ, "00600", "pip", {"off", "pip", "pbp"}),  // returns 000 0:off, 1:pip, 2:pbp
@@ -614,7 +626,7 @@ static std::vector<setting_t *> settings(
 	(new setting_t(PS,                     "00800", "osd_language", 0, 28, -100))->set_access(READ),
 	new setting_t(ALL,                     "00810", "osd_transparency", 0, 5),  // returns 000
 	new setting_t(ALL,                     "00820", "osd_timeout",0, 30),  // returns 020
-	new setting_t(PS,                      "00830", "screen_info", {"off", "on"}),
+	new setting_t(PS | MAG274,              "00830", "screen_info", {"off", "on"}),
 	// Reset is considered dangerous as well
 	// Completely disable
 	// new setting_t(ALL, WRITE,              "00840", "reset", {"-off", "on"}),  // returns 56006 - reset monitors
@@ -647,6 +659,11 @@ static std::vector<setting_t *> settings(
 	new setting_t(MPG341,                  "00910", "navi_down", {"off", "brightness", "game_mode", "screen_assistance", "alarm_clock", "input", "refresh_rate", "audio_volume"}),
 	new setting_t(MPG341,                  "00920", "navi_left", {"off", "brightness", "game_mode", "screen_assistance", "alarm_clock", "input", "refresh_rate", "audio_volume"}),
 	new setting_t(MPG341,                  "00930", "navi_right", {"off", "brightness", "game_mode", "screen_assistance", "alarm_clock", "input", "refresh_rate", "audio_volume"}),
+
+	new setting_t(MAG274,                  "00900", "navi_up", {"off", "brightness", "game_mode", "screen_assistance", "alarm_clock", "input", "refresh_rate", "info"}),
+	new setting_t(MAG274,                  "00910", "navi_down", {"off", "brightness", "game_mode", "screen_assistance", "alarm_clock", "input", "refresh_rate", "info"}),
+	new setting_t(MAG274,                  "00920", "navi_left", {"off", "brightness", "game_mode", "screen_assistance", "alarm_clock", "input", "refresh_rate", "info"}),
+	new setting_t(MAG274,                  "00930", "navi_right", {"off", "brightness", "game_mode", "screen_assistance", "alarm_clock", "input", "refresh_rate", "info"}),
 
 	new setting_t(MAG32 | MAG321 | MAG271CQ, "00900", "navi_up", {"off", "brightness", "game_mode", "screen_assistance", "alarm_clock", "input", "pip", "refresh_rate"}),
 	new setting_t(MAG32 | MAG321 | MAG271CQ, "00910", "navi_down", {"off", "brightness", "game_mode", "screen_assistance", "alarm_clock", "input", "pip", "refresh_rate"}),


### PR DESCRIPTION
Added support for the new color clamp of the new firmware released this august, and a few missing settings (Added to both firmware versions, but due to not having the original firmware I can't confirm if they works correctly or if the options are different from the current one, so someone should test them if they are indeed working).