### PR TITLE
Add MAG271C support

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ monitors only group 1 is supported.
 All monitors for which the OSD Gaming Device App is available most likely
 should be supported. There are differences between those monitors which `msigd` 
 currently does not know about.
- 
+
 If you own an MSI monitor supported by the MSI App, please provide the following
 information by opening an issue.
 
@@ -79,6 +79,7 @@ information by opening an issue.
 | MAG241CP      | ?        | Yes           | "V18" | "002"| ?              |[Manual](https://download.msi.com/archive/mnu_exe/monitor/MAG241C_CP_CR_CV_271C_CP_CR_CVv1.0_English.pdf)|
 | MAG241CV      | ?        | Yes           | "V18" | "002"| ?              |[Manual](https://download.msi.com/archive/mnu_exe/monitor/MAG241C_CP_CR_CV_271C_CP_CR_CVv1.0_English.pdf)|
 | MAG241CR      | ?        | Yes           | "V18" | "004"| ?              |[Manual](https://download.msi.com/archive/mnu_exe/monitor/MAG241C_CP_CR_CV_271C_CP_CR_CVv1.0_English.pdf)|
+| MAG271C      | FW.008 | Yes           | "V18" | "003" | TPM270WF1_HP01 |[Manual](https://download.msi.com/archive/mnu_exe/monitor/MAG241C_CP_CR_CV_271C_CP_CR_CVv1.0_English.pdf)|
 | MAG271CR      | ?        | Yes           | "V18" | "005"| ?              |[Manual](https://download.msi.com/archive/mnu_exe/monitor/MAG241C_CP_CR_CV_271C_CP_CR_CVv1.0_English.pdf)|
 | MAG271CQR     | ?        | Yes           | "V19" | "006"| TPM270WQ1_DP01 | |
 | MAG321CQR     | ?        | Yes           | "V18" | "00:"| ?              | |

--- a/src/msigd.cpp
+++ b/src/msigd.cpp
@@ -52,28 +52,29 @@ enum series_t
 	MAG321CQR      = 0x00000002,
 	MAG241C        = 0x00000004,
 	MAG241CR       = 0x00000008,
-	MAG271CR       = 0x00000010,
-	MAG271CQR      = 0x00000020,
-	MAG272         = 0x00000040,
-	MAG272CQR      = 0x00000080,
-	MAG272QP       = 0x00000100,
-	MAG272QR       = 0x00000200,
-	MAG274QRFQD    = 0x00000400,
-	MAG274QRFQD16  = 0x00000800,
-	MAG274QRFQD20  = 0x00001000,
-	PS341WU        = 0x00002000,
-	MPG341CQR      = 0x00004000,
-	MPG273CQR      = 0x00008000,
-	MPG27CQ        = 0x00010000,
-	MAG321QR       = 0x00020000,
-	MAG274R        = 0x00040000,
-	MAG251RX       = 0x00080000,
-	MAG274QRX      = 0x00100000, // enable in master once feedback received
-	MD272QP        = 0x00200000, // enable in master once feedback received
+	MAG271C        = 0x00000010,
+	MAG271CR       = 0x00000020,
+	MAG271CQR      = 0x00000040,
+	MAG272         = 0x00000080,
+	MAG272CQR      = 0x00000100,
+	MAG272QP       = 0x00000200,
+	MAG272QR       = 0x00000400,
+	MAG274QRFQD    = 0x00000800,
+	MAG274QRFQD16  = 0x00001000,
+	MAG274QRFQD20  = 0x00002000,
+	PS341WU        = 0x00004000,
+	MPG341CQR      = 0x00008000,
+	MPG273CQR      = 0x00010000,
+	MPG27CQ        = 0x00020000,
+	MAG321QR       = 0x00040000,
+	MAG274R        = 0x00080000,
+	MAG251RX       = 0x00100000,
+	MAG274QRX      = 0x00200000, // enable in master once feedback received
+	MD272QP        = 0x00400000, // enable in master once feedback received
 	QUERYONLY      = 0x01000000,
 	UNKNOWN        = 0x02000000,
 
-	MAG241GRP      = MAG241C | MAG241CR | MAG271CR,
+	MAG241GRP      = MAG241C | MAG241CR | MAG271C | MAG271CR,
 	MAG274GRP      = MAG274QRFQD | MAG274QRFQD16 | MAG274QRFQD20 | MAG274R,
 	MAG272GRP      = MAG272 | MAG272CQR | MAG272QP | MAG272QR,
 
@@ -131,6 +132,7 @@ static std::vector<identity_t> known_models =
 	{ MAG241C,           "002", "V49", "MAG241C", LT_NONE },                       // MAG241C - issue #38
 	// FIXME: Needs separate series (has RGB backlight OSD setting) - above not
 	{ MAG241CR,          "004", "V18", "MAG241CR", LT_MYSTIC },                    // MAG241CR
+	{ MAG271C,           "003", "V18", "MAG271C", LT_NONE },                       // MAG271C
 	{ MAG271CR,          "005", "V18", "MAG271CR", LT_MYSTIC },                    // MAG271CR
 	{ MAG271CQR,         "006", "V19", "MAG271CQR", LT_MYSTIC },                   // MAG271CQR, MAG271CQP?
 	{ MAG272CQR,         "00E", "V18", "MAG272CQR", LT_MYSTIC },                   // MAG272CQR


### PR DESCRIPTION
Essentially the same as MAG271CR, except no mystic LEDs.

Output of `./msigd  --info --debug --query` after applying the change:
```
DEBUG: Initializing HID lib
DEBUG: Found <MSI Gaming Controller> with serial <A02018011700>
Vendor Id:      0x1462
Product Id:     0x3fa4
Product:        MSI Gaming Controller
Serial:         A02018011700
Monitor Series: MAG271C
LED support:    None
s140:           <003>
s150:           <V18>
DEBUG: Special 01 b0: 01 5a 15 00 00 00 00 00 00 00 00 00 00 00 00 00
DEBUG: Special 01 b4: 01 5a 02 02 35 e8 00 00 00 00 00 00 00 00 00 00
macro_key : '000'
serial : 'FA6T028260719'
frequency : '120'
game_mode : '000'
black_tuner : '009'
response_time : '000'
enable_dynamic : '000'
hdcr : '000'
refresh_display : '000'
refresh_position : '000'
alarm_clock : '000'
alarm_position : '000'
screen_assistance : '000'
free_sync : '001'
pro_mode : '000'
eye_saver : '000'
image_enhancement : '000'
brightness : '065'
contrast : '062'
sharpness : '000'
color_preset : '002'
color_red : '050'
color_green : '050'
color_blue : '050'
color_rgb : 'bbb'
input : '001'
osd_language : '001'
osd_transparency : '000'
osd_timeout : '020'
sound_enable : '001'
navi_up : '002'
navi_down : '003'
navi_left : '001'
navi_right : '005'
```