### PR TITLE
Add support for MAG274QRF-QD FW.021

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,8 @@ information by opening an issue.
 | MAG274R       | ?        | Yes           | "V41" | "00Z"| ?              |[Manual](https://download.msi.com/archive/mnu_exe/monitor/Optix_MAG274_274Rv1.0_English.pdf)|
 | MAG274QRF-QD  | FW.011   | Yes           | "V43" | "00e"| AUO_M270DAN08_2| |
 | MAG274QRF-QD  | FW.015   | Yes           | "V48" | "00e"| AUO_M270DAN08_2| |
-| MAG274QRF-QD  | FW.020   | Yes           | "V56" | "00e"| AUO_M270DAN08_2|[Manual](https://download.msi.com/archive/mnu_exe/monitor/Optix_MAG274QRF_MAG274QRF-QDv1.0_English.pdf)|
+| MAG274QRF-QD  | FW.020   | Yes           | "V56" | "00e"| AUO_M270DAN08_2| |
+| MAG274QRF-QD  | FW.021   | Yes           | "V56" | "00e"| AUO_M270DAN08_2|[Manual](https://download.msi.com/archive/mnu_exe/monitor/Optix_MAG274QRF_MAG274QRF-QDv1.0_English.pdf)|
 | MAG274QRX     | ?        | Partial 2)    | "V53" | "00\|"| ?              |[Manual](https://download.msi.com/archive/mnu_exe/monitor/Optix_MAG274QRXv1.0_English.pdf)|
 | MAG270CR      | ?        | ?             | ?     |   ?  | ?              | |
 | MAG271C       | ?        | ?             | "V18" | "002"| ?              |[Manual](https://download.msi.com/archive/mnu_exe/monitor/MAG241C_CP_CR_CV_271C_CP_CR_CVv1.0_English.pdf)|

--- a/src/msigd.cpp
+++ b/src/msigd.cpp
@@ -146,7 +146,7 @@ static std::vector<identity_t> known_models =
 	{ MAG251RX,          "00B", "V18", "MAG251RX", LT_MYSTIC },                    // MAG251RX
 	{ MAG274QRFQD,       "00e", "V43", "MAG274QRF-QD FW.011", LT_MYSTIC_OPTIX },        // MAG274QRF-QD FW.011
 	{ MAG274QRFQD16,     "00e", "V48", "MAG274QRF-QD FW.015/FW.016", LT_MYSTIC_OPTIX }, // MAG274QRF-QD FW.015/FW.016
-	{ MAG274QRFQD20,     "00e", "V56", "MAG274QRF-QD FW.020", LT_MYSTIC_OPTIX },		// MAG274QRF-QD FW.020
+	{ MAG274QRFQD20,     "00e", "V56", "MAG274QRF-QD FW.020/FW.021", LT_MYSTIC_OPTIX },	// MAG274QRF-QD FW.020/FW.021
 	{ PS341WU,           "00?", "V06", "PS341WU", LT_NONE },
 	{ MAG274QRX,         "00|", "V43", "MAG274QRX", LT_MYSTIC_OPTIX, true },
 	{ MD272QP,           "00\x85", "V51", "MD272QP", LT_NONE },                    // MAG274QRF-QD FW.011


### PR DESCRIPTION
This is just cosmetics text changes, since it seems that FW.021 seems to just be internal improvements by MSI? From a quick test it seems to still be working fine using the FW.020 mappings.