### PR TITLE
Add MPG 271QRX QD OLED support

### DIFF
--- a/src/msigd.cpp
+++ b/src/msigd.cpp
@@ -72,6 +72,7 @@ enum series_t
 	MD272QP        = 0x00200000, // enable in master once feedback received
 	QUERYONLY      = 0x01000000,
 	MPG271QX       = 0x01020000,
+	MPG271QX12     = 0x01040000,
 	UNKNOWN        = 0x02000000,
 
 	MAG241GRP      = MAG241C | MAG241CR | MAG271CR,
@@ -79,12 +80,12 @@ enum series_t
 	MAG272GRP      = MAG272 | MAG272CQR | MAG272QP | MAG272QR,
 
 	MAG     = MAG321CURV | MAG321CQR | MAG272GRP | MAG271CQR | MAG241GRP | MAG274GRP,
-	MPG     = MPG273CQR | MPG341CQR | MPG27CQ | MPG271QX,
+	MPG     = MPG273CQR | MPG341CQR | MPG27CQ | MPG271QX | MPG271QX12,
 
 	HAS_LED_SETTING = MAG321CURV | MAG321QR | MAG321CQR | MAG272CQR | MAG272QR | MAG271CQR
-		| MAG241CR | MAG271CR | MAG274GRP | MAG274GRP | MPG273CQR | MPG341CQR | MAG251RX | MAG274QRX | MPG271QX,
+		| MAG241CR | MAG271CR | MAG274GRP | MAG274GRP | MPG273CQR | MPG341CQR | MAG251RX | MAG274QRX | MPG271QX | MPG271QX12,
 
-	ALL     = MAG | PS341WU | MPG | QUERYONLY | MAG321QR | MPG27CQ | MAG251RX | MAG274QRX | MD272QP | MPG271QX,
+	ALL     = MAG | PS341WU | MPG | QUERYONLY | MAG321QR | MPG27CQ | MAG251RX | MAG274QRX | MD272QP | MPG271QX | MPG271QX12,
 };
 
 static series_t operator | (series_t a, series_t b)
@@ -151,7 +152,8 @@ static std::vector<identity_t> known_models =
 	{ PS341WU,           "00?", "V06", "PS341WU", LT_NONE },
 	{ MAG274QRX,         "00|", "V43", "MAG274QRX", LT_MYSTIC_OPTIX, true },
 	{ MD272QP,           "00\x85", "V51", "MD272QP", LT_NONE },                    // MAG274QRF-QD FW.011
-	{ MPG271QX,          "00\x9e", "V20", "MPG271QX", LT_MYSTIC_OPTIX },           // MAG274QRF-QD FW.011
+	{ MPG271QX,          "00\x9e", "V20", "MPG271QX", LT_MYSTIC_OPTIX },           // MPG271QX stock firmware
+	{ MPG271QX12,        "00\x9e", "V22", "MPG271QX FW.012", LT_MYSTIC_OPTIX },    // MPG271QX FW.012
 };
 
 enum encoding_t
@@ -606,7 +608,7 @@ static std::vector<setting_t *> settings(
 	new setting_t(ALL,                     "00170", "frequency"),   // returns 060
 	new setting_t(PS341WU, READ,           "00180", "quick_charge", {"off", "on"}),  // returns 56006 on MAG, 000 on PS341WU
 
-	new setting_t(MAG321CURV | MAG321CQR | MAG272GRP | MAG271CQR | MAG241GRP | MAG274QRFQD | MAG274QRFQD16 | MAG274R | MPG | MAG321QR | MAG251RX | MAG274QRX | MPG271QX,
+	new setting_t(MAG321CURV | MAG321CQR | MAG272GRP | MAG271CQR | MAG241GRP | MAG274QRFQD | MAG274QRFQD16 | MAG274R | MPG | MAG321QR | MAG251RX | MAG274QRX | MPG271QX | MPG271QX12,
                                            "00200", "game_mode", {"user", "fps", "racing", "rts", "rpg"}),
 	new setting_t(MAG274QRFQD20,           "00200", "game_mode", {"user", "fps", "racing", "rts", "rpg", "premium_color"}),
 
@@ -617,17 +619,17 @@ static std::vector<setting_t *> settings(
 	// FIXME: MAG321CQR manual says only supported for Optix MAG322CQRV
 	new setting_t(MAG | MPG341CQR| MAG251RX,
 		                                   "00230", "enable_dynamic", {"on", "off"}),  // returns 000 - on/off only ==> on disables ZL and HDCR in OSD
-	new setting_t(MAG | MPG | MAG321QR | MAG251RX | MAG274QRX | MD272QP | MPG271QX,
+	new setting_t(MAG | MPG | MAG321QR | MAG251RX | MAG274QRX | MD272QP | MPG271QX | MPG271QX12,
 		                                   "00240", "hdcr", {"off", "on"}),
-	new setting_t(MAG | MPG | MAG321QR | MAG251RX | MAG274QRX | MD272QP | MPG271QX,
+	new setting_t(MAG | MPG | MAG321QR | MAG251RX | MAG274QRX | MD272QP | MPG271QX | MPG271QX12,
 		                                   "00250", "refresh_display", {"off", "on"}),
 	new setting_t(MAG | MPG | MAG321QR | MAG251RX | MD272QP,
 		                                   "00251", "refresh_position", {"left_top", "right_top", "left_bottom", "right_bottom"}),
-	new setting_t(MAG274QRX | MPG271QX,               "00251", "refresh_position", {"left_top", "right_top", "left_bottom", "right_bottom", "custom"}),
+	new setting_t(MAG274QRX | MPG271QX | MPG271QX12,               "00251", "refresh_position", {"left_top", "right_top", "left_bottom", "right_bottom", "custom"}),
 
 	// MPG341: Alarm settings seem to be broken.
 	//         alarm_clock_time returns an invalid response.
-	new setting_t(MAG | PS341WU | MPG273CQR | MPG27CQ | MAG321QR | MAG274QRX | MD272QP | MPG271QX,
+	new setting_t(MAG | PS341WU | MPG273CQR | MPG27CQ | MAG321QR | MAG274QRX | MD272QP | MPG271QX | MPG271QX12,
 		                                   "00260", "alarm_clock", {"off", "1", "2", "3", "4"}),
 
 	// The following have been verified only on MAG321CURV, not used in Gaming OSD
@@ -635,7 +637,7 @@ static std::vector<setting_t *> settings(
 	new setting_t(MAG321CURV,              "00261", "alarm_clock_index", 1, 4),  // FIXME: returns timeout on PS341WU
 	new setting_t(MAG321CURV | MPG273CQR | MAG321QR,  "00262", "alarm_clock_time", 0, cMAX_ALARM, -60),  // FIXME: returns timeout on PS341WU
 	new setting_t(MAG | MPG27CQ | MD272QP, "00263", "alarm_position", {"left_top", "right_top", "left_bottom", "right_bottom"}),
-	new setting_t(PS341WU | MPG273CQR | MAG321QR | MAG251RX | MAG274QRX | MPG271QX,
+	new setting_t(PS341WU | MPG273CQR | MAG321QR | MAG251RX | MAG274QRX | MPG271QX | MPG271QX12,
 		                                   "00263", "alarm_position", {"left_top", "right_top", "left_bottom", "right_bottom", "custom"}),
 
 	// alarm4x is only verified on MAG321CURV, used in Gaming OSD
@@ -649,9 +651,9 @@ static std::vector<setting_t *> settings(
 		"scale_v", "scale_h", "line_v", "line_h", "grid", "thirds", "3D_assistance"}),
 
 	(new setting_t(MAG251RX,               "00270", "screen_assistance", {"off", "icon1", "icon2", "icon3", "icon4", "icon5", "icon6"}))->set_access(READ),
-	new setting_t(MPG273CQR | MAG321QR | MAG274QRX | MPG271QX,
+	new setting_t(MPG273CQR | MAG321QR | MAG274QRX | MPG271QX | MPG271QX12,
 		                                   "00270", "smart_crosshair_icon", {"off", "icon1", "icon2", "icon3", "icon4", "icon5", "icon6"}),
-	new setting_t(MPG273CQR | MAG321QR | MAG274QRX | MPG271QX,
+	new setting_t(MPG273CQR | MAG321QR | MAG274QRX | MPG271QX | MPG271QX12,
 		                                   "00271", "smart_crosshair_color", {"white", "red", "auto"}),
 	new setting_t(UNKNOWN,                 "00271", "unknown271", 0, 100),  // returns 000, read only?
 
@@ -661,19 +663,19 @@ static std::vector<setting_t *> settings(
 	new setting_t(UNKNOWN /*MAG321CURV*/,  "00280", "unknown280"),  // returns 000, read only, write fails and monitor needs off/on cycle
 
 	// FIXME: free_sync also on MPG27CQ
-	new setting_t(MAG321CQR | MAG272GRP | MAG271CQR | MAG241GRP | MAG274GRP | MPG341CQR | MPG273CQR | MPG27CQ | MAG321QR | MD272QP | MPG271QX,
+	new setting_t(MAG321CQR | MAG272GRP | MAG271CQR | MAG241GRP | MAG274GRP | MPG341CQR | MPG273CQR | MPG27CQ | MAG321QR | MD272QP | MPG271QX | MPG271QX12,
 		                                   "00280", "free_sync", {"off", "on"}),
-	new setting_t(MAG321CURV | MAG321CQR | MAG271CQR | MPG341CQR | MPG27CQ | MPG271QX,
+	new setting_t(MAG321CURV | MAG321CQR | MAG271CQR | MPG341CQR | MPG27CQ | MPG271QX | MPG271QX12,
 		                                   "00290", "zero_latency", {"off", "on"}),  // returns 001
 
 	new setting_t(MAG272GRP | MPG273CQR | MAG321QR | MAG274R | MAG251RX | MD272QP,
 			                               "002:0", "screen_size", {"auto", "4:3", "16:9"}),
-	new setting_t(MAG274QRX | MPG271QX,               "002:0", "screen_size", {"auto", "4:3", "16:9", "1:1"}),
+	new setting_t(MAG274QRX | MPG271QX | MPG271QX12,               "002:0", "screen_size", {"auto", "4:3", "16:9", "1:1"}),
 	// FIXME: also on MPG27CQ
 	new setting_t(MAG321CURV | MAG321CQR | MAG271CQR | MPG27CQ,
 		                                   "002:0", "screen_size", {"19", "24", "4:3", "16:9"}),
 	new setting_t(PS341WU | MPG341CQR,     "002:0", "screen_size", {"auto", "4:3", "16:9", "21:9", "1:1"}),
-	new setting_t(MAG321CURV | MAG272GRP | MAG274GRP | MPG341CQR | MPG273CQR | MAG321QR | MAG251RX | MAG274QRX | MPG271QX,
+	new setting_t(MAG321CURV | MAG272GRP | MAG274GRP | MPG341CQR | MPG273CQR | MAG321QR | MAG251RX | MAG274QRX | MPG271QX | MPG271QX12,
 										   "002;0", "night_vision", {"off", "normal", "strong", "strongest", "ai"}),
 	new setting_t(MAG272GRP | MAG251RX,    "00300", "pro_mode", {"user", "reader", "cinema", "designer", "HDR"}),
 	new setting_t(MAG274QRFQD,             "00300", "pro_mode", {"user", "reader", "cinema", "office"}),
@@ -683,7 +685,7 @@ static std::vector<setting_t *> settings(
 		                                   "00300", "pro_mode", {"user", "reader", "cinema", "designer"}),
 	new setting_t(PS341WU,                 "00300", "pro_mode", {"user", "adobe_rgb", "dci_p3", "srgb", "hdr", "cinema", "reader", "bw", "dicom", "eyecare", "cal1", "cal2", "cal3"}),
 	new setting_t(MPG273CQR | MAG321QR,    "00300", "pro_mode", {"user", "anti_blue", "movie", "office", "srgb", "eco"}),
-	new setting_t(MAG274QRX | MPG271QX,               "00300", "pro_mode", {"user", "anti_blue", "movie", "office", "srgb", "adobe_rgb", "dci_p3", "eco"}),
+	new setting_t(MAG274QRX | MPG271QX | MPG271QX12,               "00300", "pro_mode", {"user", "anti_blue", "movie", "office", "srgb", "adobe_rgb", "dci_p3", "eco"}),
 	new setting_t(MD272QP,                 "00300", "pro_mode", {"eco", "user", "srgb", "anti_blue", "movie", "office", "black_white"}),
 	// low blue light on MPG273, MAG274QRX
 	new setting_t(ALL,                     "00310", "eye_saver", {"off", "on"}),  // returns 000
@@ -692,14 +694,14 @@ static std::vector<setting_t *> settings(
 	new setting_t(ALL,                     "00400", "brightness", 0, 100),  // returns 048
 	new setting_t(ALL,                     "00410", "contrast", 0, 100),  // returns 050
 	new setting_t(ALL,                     "00420", "sharpness", 0, 5),  // returns 000
-	new setting_t(MAG | MPG | MAG321QR | MAG251RX | MAG274QRX | MD272QP | MPG271QX,
+	new setting_t(MAG | MPG | MAG321QR | MAG251RX | MAG274QRX | MD272QP | MPG271QX | MPG271QX12,
 		                                   "00430", "color_preset", {"cool", "normal", "warm", "custom"}),
 	new setting_t(PS341WU,                 "00430", "color_preset", {"5000K", "5500K", "6500K", "7500K", "9300K", "10000K", "custom"}),
-	new setting_t(MAG | MPG | MAG321QR | MAG251RX | MAG274QRX | MD272QP | MPG271QX,
+	new setting_t(MAG | MPG | MAG321QR | MAG251RX | MAG274QRX | MD272QP | MPG271QX | MPG271QX12,
 		                                   "00431", "color_red", 0, 100),
-	new setting_t(MAG | MPG | MAG321QR | MAG251RX | MAG274QRX | MD272QP | MPG271QX,
+	new setting_t(MAG | MPG | MAG321QR | MAG251RX | MAG274QRX | MD272QP | MPG271QX | MPG271QX12,
 		                                   "00432", "color_green", 0, 100),
-	new setting_t(MAG | MPG | MAG321QR | MAG251RX | MAG274QRX | MD272QP | MPG271QX,
+	new setting_t(MAG | MPG | MAG321QR | MAG251RX | MAG274QRX | MD272QP | MPG271QX | MPG271QX12,
 		                                   "00433", "color_blue", 0, 100),
 	new tripple_t(ALL,                     "00434", "color_rgb"),  // returns bbb  -> value = 'b' - '0' = 98-48=50
 
@@ -713,31 +715,31 @@ static std::vector<setting_t *> settings(
 	new tripple_t(PS341WU,                 "004;0", "saturation_rgb"),
 	new tripple_t(PS341WU,                 "004;1", "saturation_cmy"),
 	new setting_t(PS341WU,                 "004:0", "gamma", {"1.8", "2", "2.2", "2.4", "2.6"}),
-	new setting_t(MAG321CURV | MAG272GRP | MAG274GRP | PS341WU | MPG341CQR | MPG273CQR | MAG321QR| MAG251RX | MAG274QRX | MPG271QX,
+	new setting_t(MAG321CURV | MAG272GRP | MAG274GRP | PS341WU | MPG341CQR | MPG273CQR | MAG321QR| MAG251RX | MAG274QRX | MPG271QX | MPG271QX12,
 		                                   "00500", "input",  {"hdmi1", "hdmi2", "dp", "usbc"}),  // returns 002  -> 0=hdmi1, 1=hdmi2, 2=dp, 3=usbc
 	new setting_t(MD272QP,                 "00500", "input",  {"hdmi1", "dp", "usbc"}),
 	new setting_t(MAG321CQR| MAG271CQR | MAG241GRP | MPG27CQ,
 		                                   "00500", "input",  {"hdmi1", "hdmi2", "dp"}),
-	new setting_t(MPG273CQR | MAG321QR | MAG274GRP | MAG274QRX | MD272QP | MPG271QX,
+	new setting_t(MPG273CQR | MAG321QR | MAG274GRP | MAG274QRX | MD272QP | MPG271QX | MPG271QX12,
 		                                   "00510", "auto_scan", {"off", "on"}),
-	new setting_t(MAG321CURV | MAG321CQR | MAG271CQR | MPG27CQ | MAG274QRX | MPG271QX,
+	new setting_t(MAG321CURV | MAG321CQR | MAG271CQR | MPG27CQ | MAG274QRX | MPG271QX | MPG271QX12,
 		                                   "00600", "pip", {"off", "pip", "pbp"}),  // returns 000 0:off, 1:pip, 2:pbp
 	new setting_t(PS341WU | MPG341CQR,     "00600", "pip", {"off", "pip", "pbp_x2", "pbp_x3", "pbp_x4"}),  // returns 000 0:off, 1:pip, 2:pbp
-	new setting_t(MAG321CURV | MAG274QRX | MPG271QX,  "00610", "pip_input", {"hdmi1", "hdmi2", "dp", "usbc"}),
-	new setting_t(MAG321CURV | MAG274QRX | MPG271QX,  "00620", "pbp_input", {"hdmi1", "hdmi2", "dp", "usbc"}),
+	new setting_t(MAG321CURV | MAG274QRX | MPG271QX | MPG271QX12,  "00610", "pip_input", {"hdmi1", "hdmi2", "dp", "usbc"}),
+	new setting_t(MAG321CURV | MAG274QRX | MPG271QX | MPG271QX12,  "00620", "pbp_input", {"hdmi1", "hdmi2", "dp", "usbc"}),
 	new setting_t(MAG271CQR | MAG321CQR | MPG27CQ,
 		                                   "00610", "pip_input", {"hdmi1", "hdmi2", "dp"}),
 	new setting_t(MAG271CQR | MAG321CQR | MPG27CQ,
 		                                   "00620", "pbp_input", {"hdmi1", "hdmi2", "dp"}),
 	new setting_t(PS341WU | MPG341CQR,     "00620", "pip_input", {"hdmi1", "hdmi2", "dp", "usbc"}),
-	new setting_t(PS341WU | MAG321CURV | MAG321CQR | MAG271CQR | MPG341CQR | MPG27CQ | MAG274QRX | MPG271QX,
+	new setting_t(PS341WU | MAG321CURV | MAG321CQR | MAG271CQR | MPG341CQR | MPG27CQ | MAG274QRX | MPG271QX | MPG271QX12,
 		                                   "00630", "pip_size", {"small", "medium", "large"}),
 	new setting_t(PS341WU | MAG321CURV | MAG321CQR | MAG271CQR | MPG341CQR | MPG27CQ,
 		                                   "00640", "pip_position", {"left_top", "right_top", "left_bottom", "right_bottom"}),
-	new setting_t(MAG274QRX | MPG271QX,               "00640", "pip_position", {"left_top", "right_top", "left_bottom", "right_bottom", "custom"}),
-	new setting_t(PS341WU | MAG321CURV | MAG321CQR | MAG271CQR | MPG341CQR | MPG27CQ | MAG274QRX | MPG271QX, WRITE,
+	new setting_t(MAG274QRX | MPG271QX | MPG271QX12,               "00640", "pip_position", {"left_top", "right_top", "left_bottom", "right_bottom", "custom"}),
+	new setting_t(PS341WU | MAG321CURV | MAG321CQR | MAG271CQR | MPG341CQR | MPG27CQ | MAG274QRX | MPG271QX | MPG271QX12, WRITE,
 		                                   "00650", "toggle_display", {"-off", "on"}),  // returns 56006
-	new setting_t(MAG321CURV | MAG321CQR | MAG271CQR | MPG27CQ | MAG274QRX | MPG271QX, WRITE,
+	new setting_t(MAG321CURV | MAG321CQR | MAG271CQR | MPG27CQ | MAG274QRX | MPG271QX | MPG271QX12, WRITE,
 		                                   "00660", "toggle_sound", {"-off", "on"}),  // returns 56006, but used to toggle audio in app, no response packet - only works with "1"
 	new setting_t(PS341WU | MPG341CQR,     "00660", "pip_sound_source", {"hdmi1", "hdmi2", "dp", "usbc"}),  // returns 56006, but used to toggle audio in app, no response packet - only works with "1"
 	new setting_t(PS341WU | MPG341CQR,     "00670", "pbp_input1", {"hdmi1", "hdmi2", "dp", "usbc"}),
@@ -754,13 +756,13 @@ static std::vector<setting_t *> settings(
 	// returns 001 -> value = '0' + language, 0 chinese, 1 English, 2 French, 3 German, ... maximum value "C"
 	// On PS341WU Series:
 	// returns 001 -> value = '0' + language, 0 chinese, 1 English, 2 French, 3 German, ... maximum value "K"
-	(new setting_t(MAG | MAG251RX | MAG274QRX | MD272QP | MPG271QX,
+	(new setting_t(MAG | MAG251RX | MAG274QRX | MD272QP | MPG271QX | MPG271QX12,
 		                                   "00800", "osd_language", 0, 19, -100))->set_access(READ),
 	(new setting_t(PS341WU,                "00800", "osd_language", 0, 28, -100))->set_access(READ),
 	new setting_t(ALL,                     "00810", "osd_transparency", 0, 5),  // returns 000
 	new setting_t(ALL,                     "00820", "osd_timeout",0, 30),  // returns 020
 	// MPG341CQR returns '__0' on screen_info
-	new setting_t(PS341WU | MAG274GRP | MAG251RX | MPG273CQR | MAG321QR | MAG274QRX | MD272QP  | MPG271QX,
+	new setting_t(PS341WU | MAG274GRP | MAG251RX | MPG273CQR | MAG321QR | MAG274QRX | MD272QP  | MPG271QX | MPG271QX12,
 		                                   "00830", "screen_info", {"off", "on"}),
 	// Reset is considered dangerous as well
 	// Completely disable
@@ -773,13 +775,13 @@ static std::vector<setting_t *> settings(
 
 	new setting_t(MPG273CQR | MAG321QR | MAG274GRP | MAG251RX | MAG274QRX | MD272QP,
 			                               "00880", "power_button", {"off", "standby"}),
-	new setting_t(MPG273CQR | MAG321QR | MAG274QRFQD | MAG274QRFQD16 | MAG274QRFQD20 | MAG274QRX | MD272QP | MPG271QX,
+	new setting_t(MPG273CQR | MAG321QR | MAG274QRFQD | MAG274QRFQD16 | MAG274QRFQD20 | MAG274QRX | MD272QP | MPG271QX | MPG271QX12,
 		                                   "008:0", "hdmi_cec", {"off", "on"}),
 	new setting_t(MPG273CQR,               "008<0", "ambient_brightness", {"off", "auto", "custom"}),
 	//new setting_t(MPG273CQR,                  "008<1", "test1"), // auto-brightness copy?
 	new setting_t(MPG273CQR,               "008<2", "ambient_rgb", {"off", "on"}),
 	new setting_t(MPG273CQR,               "008<3", "ambient_brightness_custom", 0, 100),
-	new setting_t(MPG273CQR | MAG321QR | MAG274QRX | MD272QP | MPG271QX,
+	new setting_t(MPG273CQR | MAG321QR | MAG274QRX | MD272QP | MPG271QX | MPG271QX12,
 		                                   "008>0", "kvm", {"auto", "upstream", "type_c"}),
 	new setting_t(MPG273CQR,               "008=0", "sound_tune", {"off", "on"}),
 
@@ -788,10 +790,10 @@ static std::vector<setting_t *> settings(
 	new setting_t(MPG273CQR,               "00920", "navi_left",  {"off", "brightness", "game_mode", "smart_crosshair", "alarm_clock", "input", "refresh_rate" , "info", "night_vision", "kvm"}),
 	new setting_t(MPG273CQR,               "00930", "navi_right", {"off", "brightness", "game_mode", "smart_crosshair", "alarm_clock", "input", "refresh_rate" , "info", "night_vision", "kvm"}),
 
-	new setting_t(MAG274QRX | MPG271QX,               "00900", "navi_up",    {"off", "brightness", "game_mode", "smart_crosshair", "alarm_clock", "input", "pip_pbp_mode", "refresh_rate" , "info", "night_vision", "optix_scope", "kvm"}),
-	new setting_t(MAG274QRX | MPG271QX,               "00910", "navi_down",  {"off", "brightness", "game_mode", "smart_crosshair", "alarm_clock", "input", "pip_pbp_mode", "refresh_rate" , "info", "night_vision", "optix_scope", "kvm"}),
-	new setting_t(MAG274QRX | MPG271QX,               "00920", "navi_left",  {"off", "brightness", "game_mode", "smart_crosshair", "alarm_clock", "input", "pip_pbp_mode", "refresh_rate" , "info", "night_vision", "optix_scope", "kvm"}),
-	new setting_t(MAG274QRX | MPG271QX,               "00930", "navi_right", {"off", "brightness", "game_mode", "smart_crosshair", "alarm_clock", "input", "pip_pbp_mode", "refresh_rate" , "info", "night_vision", "optix_scope", "kvm"}),
+	new setting_t(MAG274QRX | MPG271QX | MPG271QX12,               "00900", "navi_up",    {"off", "brightness", "game_mode", "smart_crosshair", "alarm_clock", "input", "pip_pbp_mode", "refresh_rate" , "info", "night_vision", "optix_scope", "kvm"}),
+	new setting_t(MAG274QRX | MPG271QX | MPG271QX12,               "00910", "navi_down",  {"off", "brightness", "game_mode", "smart_crosshair", "alarm_clock", "input", "pip_pbp_mode", "refresh_rate" , "info", "night_vision", "optix_scope", "kvm"}),
+	new setting_t(MAG274QRX | MPG271QX | MPG271QX12,               "00920", "navi_left",  {"off", "brightness", "game_mode", "smart_crosshair", "alarm_clock", "input", "pip_pbp_mode", "refresh_rate" , "info", "night_vision", "optix_scope", "kvm"}),
+	new setting_t(MAG274QRX | MPG271QX | MPG271QX12,               "00930", "navi_right", {"off", "brightness", "game_mode", "smart_crosshair", "alarm_clock", "input", "pip_pbp_mode", "refresh_rate" , "info", "night_vision", "optix_scope", "kvm"}),
 
 	new setting_t(MAG272GRP,               "00900", "navi_up",    {"off", "brightness", "game_mode", "screen_assistance", "alarm_clock", "refresh_rate" , "info"}),
 	new setting_t(MAG272GRP,               "00910", "navi_down",  {"off", "brightness", "game_mode", "screen_assistance", "alarm_clock", "refresh_rate" , "info"}),

--- a/src/msigd.cpp
+++ b/src/msigd.cpp
@@ -71,6 +71,7 @@ enum series_t
 	MAG274QRX      = 0x00100000, // enable in master once feedback received
 	MD272QP        = 0x00200000, // enable in master once feedback received
 	QUERYONLY      = 0x01000000,
+	MPG271QX       = 0x01020000,
 	UNKNOWN        = 0x02000000,
 
 	MAG241GRP      = MAG241C | MAG241CR | MAG271CR,
@@ -78,12 +79,12 @@ enum series_t
 	MAG272GRP      = MAG272 | MAG272CQR | MAG272QP | MAG272QR,
 
 	MAG     = MAG321CURV | MAG321CQR | MAG272GRP | MAG271CQR | MAG241GRP | MAG274GRP,
-	MPG     = MPG273CQR | MPG341CQR | MPG27CQ,
+	MPG     = MPG273CQR | MPG341CQR | MPG27CQ | MPG271QX,
 
 	HAS_LED_SETTING = MAG321CURV | MAG321QR | MAG321CQR | MAG272CQR | MAG272QR | MAG271CQR
-		| MAG241CR | MAG271CR | MAG274GRP | MAG274GRP | MPG273CQR | MPG341CQR | MAG251RX | MAG274QRX,
+		| MAG241CR | MAG271CR | MAG274GRP | MAG274GRP | MPG273CQR | MPG341CQR | MAG251RX | MAG274QRX | MPG271QX,
 
-	ALL     = MAG | PS341WU | MPG | QUERYONLY | MAG321QR | MPG27CQ | MAG251RX | MAG274QRX | MD272QP,
+	ALL     = MAG | PS341WU | MPG | QUERYONLY | MAG321QR | MPG27CQ | MAG251RX | MAG274QRX | MD272QP | MPG271QX,
 };
 
 static series_t operator | (series_t a, series_t b)
@@ -150,6 +151,7 @@ static std::vector<identity_t> known_models =
 	{ PS341WU,           "00?", "V06", "PS341WU", LT_NONE },
 	{ MAG274QRX,         "00|", "V43", "MAG274QRX", LT_MYSTIC_OPTIX, true },
 	{ MD272QP,           "00\x85", "V51", "MD272QP", LT_NONE },                    // MAG274QRF-QD FW.011
+	{ MPG271QX,          "00\x9e", "V20", "MPG271QX", LT_MYSTIC_OPTIX },           // MAG274QRF-QD FW.011
 };
 
 enum encoding_t
@@ -604,7 +606,7 @@ static std::vector<setting_t *> settings(
 	new setting_t(ALL,                     "00170", "frequency"),   // returns 060
 	new setting_t(PS341WU, READ,           "00180", "quick_charge", {"off", "on"}),  // returns 56006 on MAG, 000 on PS341WU
 
-	new setting_t(MAG321CURV | MAG321CQR | MAG272GRP | MAG271CQR | MAG241GRP | MAG274QRFQD | MAG274QRFQD16 | MAG274R | MPG | MAG321QR | MAG251RX | MAG274QRX,
+	new setting_t(MAG321CURV | MAG321CQR | MAG272GRP | MAG271CQR | MAG241GRP | MAG274QRFQD | MAG274QRFQD16 | MAG274R | MPG | MAG321QR | MAG251RX | MAG274QRX | MPG271QX,
                                            "00200", "game_mode", {"user", "fps", "racing", "rts", "rpg"}),
 	new setting_t(MAG274QRFQD20,           "00200", "game_mode", {"user", "fps", "racing", "rts", "rpg", "premium_color"}),
 
@@ -615,17 +617,17 @@ static std::vector<setting_t *> settings(
 	// FIXME: MAG321CQR manual says only supported for Optix MAG322CQRV
 	new setting_t(MAG | MPG341CQR| MAG251RX,
 		                                   "00230", "enable_dynamic", {"on", "off"}),  // returns 000 - on/off only ==> on disables ZL and HDCR in OSD
-	new setting_t(MAG | MPG | MAG321QR | MAG251RX | MAG274QRX | MD272QP,
+	new setting_t(MAG | MPG | MAG321QR | MAG251RX | MAG274QRX | MD272QP | MPG271QX,
 		                                   "00240", "hdcr", {"off", "on"}),
-	new setting_t(MAG | MPG | MAG321QR | MAG251RX | MAG274QRX | MD272QP,
+	new setting_t(MAG | MPG | MAG321QR | MAG251RX | MAG274QRX | MD272QP | MPG271QX,
 		                                   "00250", "refresh_display", {"off", "on"}),
 	new setting_t(MAG | MPG | MAG321QR | MAG251RX | MD272QP,
 		                                   "00251", "refresh_position", {"left_top", "right_top", "left_bottom", "right_bottom"}),
-	new setting_t(MAG274QRX,               "00251", "refresh_position", {"left_top", "right_top", "left_bottom", "right_bottom", "custom"}),
+	new setting_t(MAG274QRX | MPG271QX,               "00251", "refresh_position", {"left_top", "right_top", "left_bottom", "right_bottom", "custom"}),
 
 	// MPG341: Alarm settings seem to be broken.
 	//         alarm_clock_time returns an invalid response.
-	new setting_t(MAG | PS341WU | MPG273CQR | MPG27CQ | MAG321QR | MAG274QRX | MD272QP,
+	new setting_t(MAG | PS341WU | MPG273CQR | MPG27CQ | MAG321QR | MAG274QRX | MD272QP | MPG271QX,
 		                                   "00260", "alarm_clock", {"off", "1", "2", "3", "4"}),
 
 	// The following have been verified only on MAG321CURV, not used in Gaming OSD
@@ -633,7 +635,7 @@ static std::vector<setting_t *> settings(
 	new setting_t(MAG321CURV,              "00261", "alarm_clock_index", 1, 4),  // FIXME: returns timeout on PS341WU
 	new setting_t(MAG321CURV | MPG273CQR | MAG321QR,  "00262", "alarm_clock_time", 0, cMAX_ALARM, -60),  // FIXME: returns timeout on PS341WU
 	new setting_t(MAG | MPG27CQ | MD272QP, "00263", "alarm_position", {"left_top", "right_top", "left_bottom", "right_bottom"}),
-	new setting_t(PS341WU | MPG273CQR | MAG321QR | MAG251RX | MAG274QRX,
+	new setting_t(PS341WU | MPG273CQR | MAG321QR | MAG251RX | MAG274QRX | MPG271QX,
 		                                   "00263", "alarm_position", {"left_top", "right_top", "left_bottom", "right_bottom", "custom"}),
 
 	// alarm4x is only verified on MAG321CURV, used in Gaming OSD
@@ -647,9 +649,9 @@ static std::vector<setting_t *> settings(
 		"scale_v", "scale_h", "line_v", "line_h", "grid", "thirds", "3D_assistance"}),
 
 	(new setting_t(MAG251RX,               "00270", "screen_assistance", {"off", "icon1", "icon2", "icon3", "icon4", "icon5", "icon6"}))->set_access(READ),
-	new setting_t(MPG273CQR | MAG321QR | MAG274QRX,
+	new setting_t(MPG273CQR | MAG321QR | MAG274QRX | MPG271QX,
 		                                   "00270", "smart_crosshair_icon", {"off", "icon1", "icon2", "icon3", "icon4", "icon5", "icon6"}),
-	new setting_t(MPG273CQR | MAG321QR | MAG274QRX,
+	new setting_t(MPG273CQR | MAG321QR | MAG274QRX | MPG271QX,
 		                                   "00271", "smart_crosshair_color", {"white", "red", "auto"}),
 	new setting_t(UNKNOWN,                 "00271", "unknown271", 0, 100),  // returns 000, read only?
 
@@ -659,19 +661,19 @@ static std::vector<setting_t *> settings(
 	new setting_t(UNKNOWN /*MAG321CURV*/,  "00280", "unknown280"),  // returns 000, read only, write fails and monitor needs off/on cycle
 
 	// FIXME: free_sync also on MPG27CQ
-	new setting_t(MAG321CQR | MAG272GRP | MAG271CQR | MAG241GRP | MAG274GRP | MPG341CQR | MPG273CQR | MPG27CQ | MAG321QR | MD272QP,
+	new setting_t(MAG321CQR | MAG272GRP | MAG271CQR | MAG241GRP | MAG274GRP | MPG341CQR | MPG273CQR | MPG27CQ | MAG321QR | MD272QP | MPG271QX,
 		                                   "00280", "free_sync", {"off", "on"}),
-	new setting_t(MAG321CURV | MAG321CQR | MAG271CQR | MPG341CQR | MPG27CQ,
+	new setting_t(MAG321CURV | MAG321CQR | MAG271CQR | MPG341CQR | MPG27CQ | MPG271QX,
 		                                   "00290", "zero_latency", {"off", "on"}),  // returns 001
 
 	new setting_t(MAG272GRP | MPG273CQR | MAG321QR | MAG274R | MAG251RX | MD272QP,
 			                               "002:0", "screen_size", {"auto", "4:3", "16:9"}),
-	new setting_t(MAG274QRX,               "002:0", "screen_size", {"auto", "4:3", "16:9", "1:1"}),
+	new setting_t(MAG274QRX | MPG271QX,               "002:0", "screen_size", {"auto", "4:3", "16:9", "1:1"}),
 	// FIXME: also on MPG27CQ
 	new setting_t(MAG321CURV | MAG321CQR | MAG271CQR | MPG27CQ,
 		                                   "002:0", "screen_size", {"19", "24", "4:3", "16:9"}),
 	new setting_t(PS341WU | MPG341CQR,     "002:0", "screen_size", {"auto", "4:3", "16:9", "21:9", "1:1"}),
-	new setting_t(MAG321CURV | MAG272GRP | MAG274GRP | MPG341CQR | MPG273CQR | MAG321QR | MAG251RX | MAG274QRX,
+	new setting_t(MAG321CURV | MAG272GRP | MAG274GRP | MPG341CQR | MPG273CQR | MAG321QR | MAG251RX | MAG274QRX | MPG271QX,
 										   "002;0", "night_vision", {"off", "normal", "strong", "strongest", "ai"}),
 	new setting_t(MAG272GRP | MAG251RX,    "00300", "pro_mode", {"user", "reader", "cinema", "designer", "HDR"}),
 	new setting_t(MAG274QRFQD,             "00300", "pro_mode", {"user", "reader", "cinema", "office"}),
@@ -681,7 +683,7 @@ static std::vector<setting_t *> settings(
 		                                   "00300", "pro_mode", {"user", "reader", "cinema", "designer"}),
 	new setting_t(PS341WU,                 "00300", "pro_mode", {"user", "adobe_rgb", "dci_p3", "srgb", "hdr", "cinema", "reader", "bw", "dicom", "eyecare", "cal1", "cal2", "cal3"}),
 	new setting_t(MPG273CQR | MAG321QR,    "00300", "pro_mode", {"user", "anti_blue", "movie", "office", "srgb", "eco"}),
-	new setting_t(MAG274QRX,               "00300", "pro_mode", {"user", "anti_blue", "movie", "office", "srgb", "adobe_rgb", "dci_p3", "eco"}),
+	new setting_t(MAG274QRX | MPG271QX,               "00300", "pro_mode", {"user", "anti_blue", "movie", "office", "srgb", "adobe_rgb", "dci_p3", "eco"}),
 	new setting_t(MD272QP,                 "00300", "pro_mode", {"eco", "user", "srgb", "anti_blue", "movie", "office", "black_white"}),
 	// low blue light on MPG273, MAG274QRX
 	new setting_t(ALL,                     "00310", "eye_saver", {"off", "on"}),  // returns 000
@@ -690,14 +692,14 @@ static std::vector<setting_t *> settings(
 	new setting_t(ALL,                     "00400", "brightness", 0, 100),  // returns 048
 	new setting_t(ALL,                     "00410", "contrast", 0, 100),  // returns 050
 	new setting_t(ALL,                     "00420", "sharpness", 0, 5),  // returns 000
-	new setting_t(MAG | MPG | MAG321QR | MAG251RX | MAG274QRX | MD272QP,
+	new setting_t(MAG | MPG | MAG321QR | MAG251RX | MAG274QRX | MD272QP | MPG271QX,
 		                                   "00430", "color_preset", {"cool", "normal", "warm", "custom"}),
 	new setting_t(PS341WU,                 "00430", "color_preset", {"5000K", "5500K", "6500K", "7500K", "9300K", "10000K", "custom"}),
-	new setting_t(MAG | MPG | MAG321QR | MAG251RX | MAG274QRX | MD272QP,
+	new setting_t(MAG | MPG | MAG321QR | MAG251RX | MAG274QRX | MD272QP | MPG271QX,
 		                                   "00431", "color_red", 0, 100),
-	new setting_t(MAG | MPG | MAG321QR | MAG251RX | MAG274QRX | MD272QP,
+	new setting_t(MAG | MPG | MAG321QR | MAG251RX | MAG274QRX | MD272QP | MPG271QX,
 		                                   "00432", "color_green", 0, 100),
-	new setting_t(MAG | MPG | MAG321QR | MAG251RX | MAG274QRX | MD272QP,
+	new setting_t(MAG | MPG | MAG321QR | MAG251RX | MAG274QRX | MD272QP | MPG271QX,
 		                                   "00433", "color_blue", 0, 100),
 	new tripple_t(ALL,                     "00434", "color_rgb"),  // returns bbb  -> value = 'b' - '0' = 98-48=50
 
@@ -711,31 +713,31 @@ static std::vector<setting_t *> settings(
 	new tripple_t(PS341WU,                 "004;0", "saturation_rgb"),
 	new tripple_t(PS341WU,                 "004;1", "saturation_cmy"),
 	new setting_t(PS341WU,                 "004:0", "gamma", {"1.8", "2", "2.2", "2.4", "2.6"}),
-	new setting_t(MAG321CURV | MAG272GRP | MAG274GRP | PS341WU | MPG341CQR | MPG273CQR | MAG321QR| MAG251RX | MAG274QRX,
+	new setting_t(MAG321CURV | MAG272GRP | MAG274GRP | PS341WU | MPG341CQR | MPG273CQR | MAG321QR| MAG251RX | MAG274QRX | MPG271QX,
 		                                   "00500", "input",  {"hdmi1", "hdmi2", "dp", "usbc"}),  // returns 002  -> 0=hdmi1, 1=hdmi2, 2=dp, 3=usbc
 	new setting_t(MD272QP,                 "00500", "input",  {"hdmi1", "dp", "usbc"}),
 	new setting_t(MAG321CQR| MAG271CQR | MAG241GRP | MPG27CQ,
 		                                   "00500", "input",  {"hdmi1", "hdmi2", "dp"}),
-	new setting_t(MPG273CQR | MAG321QR | MAG274GRP | MAG274QRX | MD272QP,
+	new setting_t(MPG273CQR | MAG321QR | MAG274GRP | MAG274QRX | MD272QP | MPG271QX,
 		                                   "00510", "auto_scan", {"off", "on"}),
-	new setting_t(MAG321CURV | MAG321CQR | MAG271CQR | MPG27CQ | MAG274QRX,
+	new setting_t(MAG321CURV | MAG321CQR | MAG271CQR | MPG27CQ | MAG274QRX | MPG271QX,
 		                                   "00600", "pip", {"off", "pip", "pbp"}),  // returns 000 0:off, 1:pip, 2:pbp
 	new setting_t(PS341WU | MPG341CQR,     "00600", "pip", {"off", "pip", "pbp_x2", "pbp_x3", "pbp_x4"}),  // returns 000 0:off, 1:pip, 2:pbp
-	new setting_t(MAG321CURV | MAG274QRX,  "00610", "pip_input", {"hdmi1", "hdmi2", "dp", "usbc"}),
-	new setting_t(MAG321CURV | MAG274QRX,  "00620", "pbp_input", {"hdmi1", "hdmi2", "dp", "usbc"}),
+	new setting_t(MAG321CURV | MAG274QRX | MPG271QX,  "00610", "pip_input", {"hdmi1", "hdmi2", "dp", "usbc"}),
+	new setting_t(MAG321CURV | MAG274QRX | MPG271QX,  "00620", "pbp_input", {"hdmi1", "hdmi2", "dp", "usbc"}),
 	new setting_t(MAG271CQR | MAG321CQR | MPG27CQ,
 		                                   "00610", "pip_input", {"hdmi1", "hdmi2", "dp"}),
 	new setting_t(MAG271CQR | MAG321CQR | MPG27CQ,
 		                                   "00620", "pbp_input", {"hdmi1", "hdmi2", "dp"}),
 	new setting_t(PS341WU | MPG341CQR,     "00620", "pip_input", {"hdmi1", "hdmi2", "dp", "usbc"}),
-	new setting_t(PS341WU | MAG321CURV | MAG321CQR | MAG271CQR | MPG341CQR | MPG27CQ | MAG274QRX,
+	new setting_t(PS341WU | MAG321CURV | MAG321CQR | MAG271CQR | MPG341CQR | MPG27CQ | MAG274QRX | MPG271QX,
 		                                   "00630", "pip_size", {"small", "medium", "large"}),
 	new setting_t(PS341WU | MAG321CURV | MAG321CQR | MAG271CQR | MPG341CQR | MPG27CQ,
 		                                   "00640", "pip_position", {"left_top", "right_top", "left_bottom", "right_bottom"}),
-	new setting_t(MAG274QRX,               "00640", "pip_position", {"left_top", "right_top", "left_bottom", "right_bottom", "custom"}),
-	new setting_t(PS341WU | MAG321CURV | MAG321CQR | MAG271CQR | MPG341CQR | MPG27CQ | MAG274QRX, WRITE,
+	new setting_t(MAG274QRX | MPG271QX,               "00640", "pip_position", {"left_top", "right_top", "left_bottom", "right_bottom", "custom"}),
+	new setting_t(PS341WU | MAG321CURV | MAG321CQR | MAG271CQR | MPG341CQR | MPG27CQ | MAG274QRX | MPG271QX, WRITE,
 		                                   "00650", "toggle_display", {"-off", "on"}),  // returns 56006
-	new setting_t(MAG321CURV | MAG321CQR | MAG271CQR | MPG27CQ | MAG274QRX, WRITE,
+	new setting_t(MAG321CURV | MAG321CQR | MAG271CQR | MPG27CQ | MAG274QRX | MPG271QX, WRITE,
 		                                   "00660", "toggle_sound", {"-off", "on"}),  // returns 56006, but used to toggle audio in app, no response packet - only works with "1"
 	new setting_t(PS341WU | MPG341CQR,     "00660", "pip_sound_source", {"hdmi1", "hdmi2", "dp", "usbc"}),  // returns 56006, but used to toggle audio in app, no response packet - only works with "1"
 	new setting_t(PS341WU | MPG341CQR,     "00670", "pbp_input1", {"hdmi1", "hdmi2", "dp", "usbc"}),
@@ -752,13 +754,13 @@ static std::vector<setting_t *> settings(
 	// returns 001 -> value = '0' + language, 0 chinese, 1 English, 2 French, 3 German, ... maximum value "C"
 	// On PS341WU Series:
 	// returns 001 -> value = '0' + language, 0 chinese, 1 English, 2 French, 3 German, ... maximum value "K"
-	(new setting_t(MAG | MAG251RX | MAG274QRX | MD272QP,
+	(new setting_t(MAG | MAG251RX | MAG274QRX | MD272QP | MPG271QX,
 		                                   "00800", "osd_language", 0, 19, -100))->set_access(READ),
 	(new setting_t(PS341WU,                "00800", "osd_language", 0, 28, -100))->set_access(READ),
 	new setting_t(ALL,                     "00810", "osd_transparency", 0, 5),  // returns 000
 	new setting_t(ALL,                     "00820", "osd_timeout",0, 30),  // returns 020
 	// MPG341CQR returns '__0' on screen_info
-	new setting_t(PS341WU | MAG274GRP | MAG251RX | MPG273CQR | MAG321QR | MAG274QRX | MD272QP,
+	new setting_t(PS341WU | MAG274GRP | MAG251RX | MPG273CQR | MAG321QR | MAG274QRX | MD272QP  | MPG271QX,
 		                                   "00830", "screen_info", {"off", "on"}),
 	// Reset is considered dangerous as well
 	// Completely disable
@@ -771,13 +773,13 @@ static std::vector<setting_t *> settings(
 
 	new setting_t(MPG273CQR | MAG321QR | MAG274GRP | MAG251RX | MAG274QRX | MD272QP,
 			                               "00880", "power_button", {"off", "standby"}),
-	new setting_t(MPG273CQR | MAG321QR | MAG274QRFQD | MAG274QRFQD16 | MAG274QRFQD20 | MAG274QRX | MD272QP,
+	new setting_t(MPG273CQR | MAG321QR | MAG274QRFQD | MAG274QRFQD16 | MAG274QRFQD20 | MAG274QRX | MD272QP | MPG271QX,
 		                                   "008:0", "hdmi_cec", {"off", "on"}),
 	new setting_t(MPG273CQR,               "008<0", "ambient_brightness", {"off", "auto", "custom"}),
 	//new setting_t(MPG273CQR,                  "008<1", "test1"), // auto-brightness copy?
 	new setting_t(MPG273CQR,               "008<2", "ambient_rgb", {"off", "on"}),
 	new setting_t(MPG273CQR,               "008<3", "ambient_brightness_custom", 0, 100),
-	new setting_t(MPG273CQR | MAG321QR | MAG274QRX | MD272QP,
+	new setting_t(MPG273CQR | MAG321QR | MAG274QRX | MD272QP | MPG271QX,
 		                                   "008>0", "kvm", {"auto", "upstream", "type_c"}),
 	new setting_t(MPG273CQR,               "008=0", "sound_tune", {"off", "on"}),
 
@@ -786,10 +788,10 @@ static std::vector<setting_t *> settings(
 	new setting_t(MPG273CQR,               "00920", "navi_left",  {"off", "brightness", "game_mode", "smart_crosshair", "alarm_clock", "input", "refresh_rate" , "info", "night_vision", "kvm"}),
 	new setting_t(MPG273CQR,               "00930", "navi_right", {"off", "brightness", "game_mode", "smart_crosshair", "alarm_clock", "input", "refresh_rate" , "info", "night_vision", "kvm"}),
 
-	new setting_t(MAG274QRX,               "00900", "navi_up",    {"off", "brightness", "game_mode", "smart_crosshair", "alarm_clock", "input", "pip_pbp_mode", "refresh_rate" , "info", "night_vision", "optix_scope", "kvm"}),
-	new setting_t(MAG274QRX,               "00910", "navi_down",  {"off", "brightness", "game_mode", "smart_crosshair", "alarm_clock", "input", "pip_pbp_mode", "refresh_rate" , "info", "night_vision", "optix_scope", "kvm"}),
-	new setting_t(MAG274QRX,               "00920", "navi_left",  {"off", "brightness", "game_mode", "smart_crosshair", "alarm_clock", "input", "pip_pbp_mode", "refresh_rate" , "info", "night_vision", "optix_scope", "kvm"}),
-	new setting_t(MAG274QRX,               "00930", "navi_right", {"off", "brightness", "game_mode", "smart_crosshair", "alarm_clock", "input", "pip_pbp_mode", "refresh_rate" , "info", "night_vision", "optix_scope", "kvm"}),
+	new setting_t(MAG274QRX | MPG271QX,               "00900", "navi_up",    {"off", "brightness", "game_mode", "smart_crosshair", "alarm_clock", "input", "pip_pbp_mode", "refresh_rate" , "info", "night_vision", "optix_scope", "kvm"}),
+	new setting_t(MAG274QRX | MPG271QX,               "00910", "navi_down",  {"off", "brightness", "game_mode", "smart_crosshair", "alarm_clock", "input", "pip_pbp_mode", "refresh_rate" , "info", "night_vision", "optix_scope", "kvm"}),
+	new setting_t(MAG274QRX | MPG271QX,               "00920", "navi_left",  {"off", "brightness", "game_mode", "smart_crosshair", "alarm_clock", "input", "pip_pbp_mode", "refresh_rate" , "info", "night_vision", "optix_scope", "kvm"}),
+	new setting_t(MAG274QRX | MPG271QX,               "00930", "navi_right", {"off", "brightness", "game_mode", "smart_crosshair", "alarm_clock", "input", "pip_pbp_mode", "refresh_rate" , "info", "night_vision", "optix_scope", "kvm"}),
 
 	new setting_t(MAG272GRP,               "00900", "navi_up",    {"off", "brightness", "game_mode", "screen_assistance", "alarm_clock", "refresh_rate" , "info"}),
 	new setting_t(MAG272GRP,               "00910", "navi_down",  {"off", "brightness", "game_mode", "screen_assistance", "alarm_clock", "refresh_rate" , "info"}),

--- a/src/phid.h
+++ b/src/phid.h
@@ -63,6 +63,7 @@ public:
 	static int get_device_list(logger_t &logger, unsigned idVendor, unsigned idProduct,
 		device_info_list &list)
 	{
+		(void) logger; // Unused variable
 		hid_init();
 		hid_device_info *dil_list = hid_enumerate(idVendor, idProduct);
 		hid_device_info *dil = dil_list;
@@ -91,6 +92,7 @@ protected:
 		void *bytes, int size, int timeout)
 	{
 		auto p(static_cast<const unsigned char *>(bytes));
+		(void) timeout; // Unused variable
 		// do basic checks
 		if ((value & 0xff00) != 0x0300 || (value & 0x00ff) != p[0]
 			|| requesttype != 0x21 || request != 0x09 || index != 0)
@@ -111,6 +113,7 @@ protected:
 		void *bytes, int size, int timeout, int &ret_size)
 	{
 		auto p(static_cast<unsigned char *>(bytes));
+		(void) timeout; // Unused variable
 		// do basic checks
 		if ((value & 0xff00) != 0x0300 || (value & 0x00ff) != p[0]
 			|| requesttype != 0xa1 || request != 0x01 || index != 0)

--- a/src/psteelseries.h
+++ b/src/psteelseries.h
@@ -14,6 +14,7 @@
 
 #include <array>
 #include <vector>
+#include <cstdint>
 
 struct steel_rgb_entry
 {


### PR DESCRIPTION
Also included FW 0.12 support.

There's a FW 0.11 as well, and it's _probably_ just V21, but since my monitor is now on 0.12, I wasn't able to confirm, and so I didn't add it.

Changes to files other than `src/msigd.cpp` were just to get it to compile on my system. Not sure why they were required.