### PR TITLE
Add support for MPG 274URDFW E16M (and accept newer USB product strings)

### DIFF
--- a/src/msigd.cpp
+++ b/src/msigd.cpp
@@ -1673,14 +1673,14 @@ int main (int argc, char **argv)
 		int idx = 1;
 		for (auto &e : monitor_list)
 		{
-			mondev_t mon(logger, e, "MSI Gaming Controller", "");
+			mondev_t mon(logger, e, "", "");
 			pprintf("%d,%s,%s,%s,%s\n", idx, mon.serial(), mon.manufacturer(), mon.product(), e.path);
 			idx ++;
 		}
 		//return E_OK;
 	}
 
-	mondev_t usb(logger, monitor_list[monitor ? monitor - 1 : 0], "MSI Gaming Controller", serial);
+	mondev_t usb(logger, monitor_list[monitor ? monitor - 1 : 0], "", serial);
 
 	if (usb)
 	{

--- a/src/msigd.cpp
+++ b/src/msigd.cpp
@@ -150,6 +150,7 @@ static std::vector<identity_t> known_models =
 	{ PS341WU,           "00?", "V06", "PS341WU", LT_NONE },
 	{ MAG274QRX,         "00|", "V43", "MAG274QRX", LT_MYSTIC_OPTIX, true },
 	{ MD272QP,           "00\x85", "V51", "MD272QP", LT_NONE },                    // MAG274QRF-QD FW.011
+	{ MAG274QRX,         "00\xb4", "V21", "MPG 274URDFW E16M", LT_MYSTIC_OPTIX }, // MPG 274URDFW E16M (4K dual-mode QD-OLED, mapped to MAG274QRX)
 };
 
 enum encoding_t

--- a/src/phid.h
+++ b/src/phid.h
@@ -249,7 +249,7 @@ private:
 
 			m_vendor_id = info.idVendor;
 			m_product_id = info.idProduct;
-			if (sProduct != m_product)
+			if (!sProduct.empty() && sProduct != m_product)
 			{
 				m_log(DEBUG, "Product Id <%s> does not match requested <%s>", m_product, sProduct);
 				return 1;


### PR DESCRIPTION
## Summary

Adds support for the **MSI MPG 274URDFW E16M** — a 27\" 4K dual-mode QD-OLED gaming monitor (USB VID `0x1462` / PID `0x3fa4`).

Two commits, intended to be reviewed independently:

### 1. Allow opening with an empty USB product-string filter

Newer MSI gaming monitors no longer report `\"MSI Gaming Controller\"` as their USB product descriptor — the MPG 274URDFW E16M reports `\"MSI Monitor MPG 274URDFW E16M\"`, and based on the [msi-mpg-491cqp-control](https://github.com/hamishmorgan/msi-mpg-491cqp-control) project the same is true of the MPG 491CQP. The existing strict equality check in `phid.h` causes \`mondev_t\` to fail to open, even though `hid_enumerate` has already filtered by VID/PID — so without this change, the second commit's \`known_models\` entry alone wouldn't help (the device still wouldn't open).

The fix is minimal: skip the product-string compare when the requested product is empty (matching the existing serial-number behaviour), and pass an empty string from the two call sites in `main()`. Existing monitors that report `\"MSI Gaming Controller\"` continue to work — `hid_enumerate(0x1462, 0x3fa4)` still selects them.

If you'd prefer a less invasive variant (e.g. accepting both `\"MSI Gaming Controller\"` and `\"MSI Monitor *\"` patterns), happy to rework.

### 2. Add MPG 274URDFW E16M to `known_models`

The monitor identifies itself as `s140 = \"00\\xb4\"`, `s150 = \"V21\"` — values not matched by any existing entry, leaving users on the `QUERYONLY` fallback with write access disabled.

Following the pattern of #66 (mapping a new ID to an existing series), this maps the new IDs to the existing **MAG274QRX** profile. The two panels share the same 4-input set (`hdmi1/hdmi2/dp/usbc` at register `00500`), KVM, `smart_crosshair`, and broadly the same OSD layout, so reusing MAG274QRX's settings table is the lowest-risk option. The read-only `, true` gate is dropped on this entry, matching the MPG271QX additions in #64.

## Verified on macOS / Apple Silicon, firmware V21

\`\`\`
\$ msigd --info
Vendor Id:      0x1462
Product Id:     0x3fa4
Product:        MSI Monitor MPG 274URDFW E16M
Serial:         A02025040703
Monitor Series: MPG 274URDFW E16M
LED support:    MysticOptix

\$ msigd -q -f brightness,contrast,input,frequency,kvm,auto_scan
frequency : 120
brightness : 44
contrast : 70
input : usbc
kvm : type_c
auto_scan : on

\$ msigd --input usbc   # no-op write to current value, exit 0
\`\`\`

Brightness/contrast match the OSD exactly, and the input read-back tracks the actual active source through hardware OSD switches, confirming register `00500` maps correctly on this panel.

Happy to iterate or split the two commits into separate PRs if that's easier to land.